### PR TITLE
Fix Slab Duplication

### DIFF
--- a/src/main/java/io/github/andrew6rant/autoslabs/mixin/SlabBlockMixin.java
+++ b/src/main/java/io/github/andrew6rant/autoslabs/mixin/SlabBlockMixin.java
@@ -69,7 +69,8 @@ public class SlabBlockMixin extends Block implements Waterloggable {
 	@Override
 	public void afterBreak(World world, PlayerEntity player, BlockPos pos, BlockState state, @Nullable BlockEntity blockEntity, ItemStack stack) {
 		if (player.isSneaking()) {
-			super.afterBreak(world, player, pos, state.with(TYPE, DOUBLE), blockEntity, stack);
+			//Should ensure that if the player mines a single slab, it drops the correct amount
+			super.afterBreak(world, player, pos, state.with(TYPE, state.get(SlabBlock.TYPE)), blockEntity, stack);
 		} else {
 			super.afterBreak(world, player, pos, state.with(TYPE, TOP), blockEntity, stack);
 		}


### PR DESCRIPTION
Solves #8 . This is the solution I came up with that seemed to work pretty well. Removing the `player.isSneaking()` if statement caused the initial duplication to be fixed, but then caused more duplication elsewhere, so that's why I've kept that there. If you see anything wrong with my solution, please let me know and I'll try to fix it.